### PR TITLE
py2by.py now properly translates python to bython, no -i flag required

### DIFF
--- a/etc/py2by.1
+++ b/etc/py2by.1
@@ -16,8 +16,6 @@ Show help message and exit.
 .BR \-v ", " \-\-version
 Show version number and exit.
 .TP
-.BR \-i ", " \-\-indent_style \fI " " INDENT_STYLE\fR
-Specify the indentation style. Available options are: 1s (1 space), 2s (2 spaces), 4s (4 spaces), 8s (8 spaces) and t (tabs). Default is 4s (this means that if this argument is omitted, 4 spaces is assumed).
 .SH SEE ALSO
 bython(1)
 .SH AUTHOR

--- a/src/py2by.py
+++ b/src/py2by.py
@@ -3,30 +3,7 @@ import os
 import re
 import argparse
 import sys
-
-
-def parse_indent_style_input(indentinput):
-    if not indentinput:
-        return "    "
-
-    elif indentinput[0] == "1s":
-        return " "
-
-    elif indentinput[0] == "2s":
-        return "  "
-
-    elif indentinput[0] == "4s":
-        return "    "
-
-    elif indentinput[0] == "8s":
-        return "        "
-
-    elif indentinput[0] == "t":
-        return "\t"
-
-    else:
-        return None
-
+from tokenize import tokenize, tok_name, INDENT, DEDENT, NAME
 
 def ends_in_py(word):
     return word[-3:] == ".py"
@@ -35,98 +12,79 @@ def ends_in_py(word):
 def change_file_name(name):
     if ends_in_py(name):
         return name[:-3] + ".by"
-
     else:
         return name + ".by"
 
 
-def count_indent_level(whitespace, indent_symbol):
+def reverse_parse(filename):
 
-    new_whitespace, numsubs = re.subn(indent_symbol, "", whitespace)
-
-    if not new_whitespace == "":
-        # Not all whitespace was consumed => illigal indentation
-        raise RuntimeError("Illegal indentation detected.\nMaybe the selected indentation style is wrong?")
-
-    else:
-        return numsubs
-
-
-
-def reverse_parse(filename, indent_style):
-    indent_symbol = parse_indent_style_input(indent_style)
-
-    if not indent_symbol:
-        raise RuntimeError("%s is not a valid indentation style!" % (indent_style))
-
-    infile = open(filename, "r")
-    outfile = open(change_file_name(filename), "w")
-
-    last_line = ""
-    last_level = 0
-
-    num_open = 0
-    num_close = 0
-
-    level = 0
-
-    for line in infile:
-        if not line.strip() == "":
-            if line in ("\n", "\n\r", "\r\n"):
-                leading_whitespace = ""
-
-            else:
-                leading_whitespace = line.split(line.lstrip())[0]
-
-            level = count_indent_level(leading_whitespace, indent_symbol)
-
-
-        new_last, num_subs = re.subn(r"\s*:$", " {", last_line)
-        num_open += num_subs
-        outfile.write(new_last)
-
-        if level < last_level:
-            decrese = last_level - level
-            for i in range(decrese):
-                outfile.write((level + decrese - i -1)*indent_symbol + "}\n")
-                num_close += 1
-
-        last_line = line
-        last_level = level
-
-
-    outfile.write(last_line)
-
-    if last_level > 0:
-        outfile.write("\n")
-        decrese = last_level
-        for i in range(decrese):
-            outfile.write((decrese - i - 1)*indent_symbol + "}\n")
-            num_close += 1
-
-
-
-    if num_open > num_close:
-        outfile.write("}\n")
-        num_close += 1
-
-    if (num_open != num_close):
-        raise RuntimeError("Unmatching number of braces created.")
-
+    # Open a file as bytes
+    infile = open(filename, "rb")
+    inlines = infile.readlines()
+    # Reformat the contents for later modifications
+    for index, line in enumerate(inlines):
+        inlines[index] = line.decode("utf-8")
+        inlines[index] = inlines[index].rstrip()
+    # Tokenize the same file, close it
+    infile.seek(0)
+    tokens = list(tokenize(infile.readline))
     infile.close()
-    outfile.close()
+    
+    # Stores a list of tuples for INDENT/DEDENT
+    # (token, line_number, position_in_line)
+    indent_tracker = []
+    
+    # Track line by line the indentation position,
+    #  used to populate indent_tracker with the proper token and brace
+    #  position, using indent_levels as a stack.
+    indent_levels = []
+    position = 0;
+    line_of_last_name_token = 0;
+    for token in tokens:
+        current_line = token.start[0]
+        if ((token.exact_type == NAME)
+            and line_of_last_name_token != current_line):
+            line_of_last_name_token = current_line
+            position = token.start[1]
+        if (token.exact_type == INDENT):
+            indent_levels.append(position)
+            indent_tracker.append((INDENT,current_line,position))
+        if (token.exact_type == DEDENT):
+            indent_tracker.append((DEDENT,current_line,indent_levels.pop()))
+    
+    # Add braces where necessary, keeping count of how many extra
+    # have been added
+    extra = 0
+    for indent in indent_tracker:
+        token = indent[0]
+        index = indent[1]
+        position = indent[2]
+        inlines.insert(
+            index + extra - 1,
+            " " * position
+            + ("}","{")[token==INDENT]
+        )
+        extra += 1
+
+    outfile = open(change_file_name(filename),"w")
+    for line in inlines:
+        print(line,file=outfile)
 
 
 def main():
-    argparser = argparse.ArgumentParser("py2by", description="py2by translates python to bython", formatter_class=argparse.RawTextHelpFormatter)
-    argparser.add_argument("-v", "--version", action="version", version="py2by is a part of Bython v0.3\nMathias Lohne 2017")
-    argparser.add_argument("input", type=str, help="python file to translate", nargs=1)
-    argparser.add_argument("-i", "--indent_style", type=str, help="style of indentation to look for: 1s, 2s, 4s, 8s or t (default: 4s)", nargs=1)
+    argparser = argparse.ArgumentParser("py2by",
+        description="py2by translates python to bython",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    argparser.add_argument("-v", "--version", action="version",
+        version="py2by is a part of Bython v0.3\nMathias Lohne 2017")
+    argparser.add_argument("input", type=str,
+        help="python file to translate", nargs=1)
 
     cmd_args = argparser.parse_args()
 
     try:
-        reverse_parse(cmd_args.input[0], cmd_args.indent_style)
+        reverse_parse(cmd_args.input[0])
 
     except RuntimeError as e:
         print("Error: %s" % str(e) , file=sys.stderr)


### PR DESCRIPTION
This is an update of py2by.py and the relevant man page.

py2by now adds indentation based off the Python internal tokenizer, meaning it's not reliant on whitespace assumptions. Should be more reliable, and get rid of a lot of (if not all) cases where py2by failed on valid python code.